### PR TITLE
feat(model): Implement models for user resource.

### DIFF
--- a/carousel-model/Cargo.toml
+++ b/carousel-model/Cargo.toml
@@ -4,3 +4,7 @@ description = "Twitch API models for the carousel ecosystem."
 version = "1.0.0"
 authors = ["abstraq<abstraq@outlook.com>"]
 edition = "2021"
+
+[dependencies]
+time = { version = "0.3", features = ["serde", "serde-well-known"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/carousel-model/src/lib.rs
+++ b/carousel-model/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/carousel-model/src/user/mod.rs
+++ b/carousel-model/src/user/mod.rs
@@ -1,0 +1,3 @@
+mod user_data;
+
+pub use user_data::*;

--- a/carousel-model/src/user/mod.rs
+++ b/carousel-model/src/user/mod.rs
@@ -1,3 +1,5 @@
 mod user_data;
+mod user_follow_data;
 
 pub use user_data::*;
+pub use user_follow_data::*;

--- a/carousel-model/src/user/mod.rs
+++ b/carousel-model/src/user/mod.rs
@@ -1,5 +1,7 @@
+mod user_block_data;
 mod user_data;
 mod user_follow_data;
 
+pub use user_block_data::*;
 pub use user_data::*;
 pub use user_follow_data::*;

--- a/carousel-model/src/user/user_block_data.rs
+++ b/carousel-model/src/user/user_block_data.rs
@@ -1,0 +1,17 @@
+use serde::Deserialize;
+
+/// Information about a user that has been blocked by the authenticated user.
+/// Returned from the GET /users/blocks endpoint.
+///
+/// See https://dev.twitch.tv/docs/api/reference#get-users-blocks for more information.
+#[derive(Debug, Deserialize)]
+pub struct UserBlockData {
+	/// The id of the blocked user.
+	pub user_id: String,
+
+	/// The login of the blocked user.
+	pub user_login: String,
+
+	/// The display name of the blocked user.
+	pub display_name: String,
+}

--- a/carousel-model/src/user/user_data.rs
+++ b/carousel-model/src/user/user_data.rs
@@ -1,0 +1,76 @@
+use serde::Deserialize;
+use time::OffsetDateTime;
+
+/// Information about the user returned from the twitch GET /users endpoint.
+///
+/// The `type` field in the response is renamed to `role` to avoid a conflict
+/// with the `type` keyword.
+///
+/// The `email` field is an optional field as it is only returned when the
+/// application has the `user:read:email` scope.
+///
+/// See https://dev.twitch.tv/docs/api/reference#get-users for more information.
+#[derive(Debug, Deserialize)]
+pub struct UserData {
+	/// The current contract the user has with Twitch.
+	pub broadcaster_type: BroadcasterType,
+
+	/// The user's channel description.
+	pub description: String,
+
+	/// The user's display name.
+	pub display_name: String,
+
+	/// The user's unique identifier. This should be preferred over the
+	/// `login` when possible.
+	pub id: String,
+
+	/// The user's login name.
+	pub login: String,
+
+	/// The image displayed when the user is offline.
+	pub offline_image_url: String,
+
+	/// The user's profile image.
+	pub profile_image_url: String,
+
+	/// The user's global role on Twitch.
+	#[serde(rename = "type")]
+	pub role: UserRole,
+
+	/// The user's email address. This is only returned when the application
+	/// has the `user:read:email` scope.
+	pub email: Option<String>,
+
+	/// The date the user's account was created.
+	#[serde(with = "time::serde::iso8601")]
+	pub created_at: OffsetDateTime,
+}
+
+/// Represents the different broadcaster types a user can be.
+#[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum BroadcasterType {
+	/// Represents a user who is a Twitch partner.
+	Partner,
+	/// Represents a user who is a Twitch affiliate.
+	Affiliate,
+	/// Represents a user who is neither a partner nor an affiliate.
+	#[serde(rename = "")]
+	None,
+}
+
+/// Represents the different global roles a user can have on Twitch.
+#[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum UserRole {
+	/// Represents a user who is a Twitch staff member.
+	Staff,
+	/// Represents a user who is a Twitch admin.
+	Admin,
+	/// Represents a user who is a Twitch global moderator.
+	GlobalMod,
+	/// Represents a user who has no global role on Twitch.
+	#[serde(rename = "")]
+	None,
+}

--- a/carousel-model/src/user/user_follow_data.rs
+++ b/carousel-model/src/user/user_follow_data.rs
@@ -1,0 +1,32 @@
+use serde::Deserialize;
+use time::OffsetDateTime;
+
+/// Information about a follow relationship between two users returned
+/// from the GET /users/follows endpoint.
+///
+/// See https://dev.twitch.tv/docs/api/reference#get-users-follows for
+/// more information.
+#[derive(Debug, Deserialize)]
+pub struct UserFollowData {
+	/// The id of the user being followed by the user specified by `from_id`.
+	pub to_id: String,
+
+	/// The login of the user being followed by the user specified by `from_id`.
+	pub to_login: String,
+
+	/// The display name of the user being followed by the user specified by `from_id`.
+	pub to_name: String,
+
+	/// The id of the user following the user specified by `to_id`.
+	pub from_id: String,
+
+	/// The login of the user following the user specified by `to_id`.
+	pub from_login: String,
+
+	/// The display name of the user following the user specified by `to_id`.
+	pub from_name: String,
+
+	/// The date the user started following the user specified by `to_id`.
+	#[serde(with = "time::serde::iso8601")]
+	pub followed_at: OffsetDateTime,
+}


### PR DESCRIPTION
Implements the response data models for the GET endpoints of the user resource in Twitch API. 

- [x] Get Users (documented)
- [x] Get User Follows (documented)
- [x] Get User Block List (documented)
- [ ] Get User Extensions (not planned)
- [ ] Get User Active Extensions (not planned)